### PR TITLE
hide 'Edições Anteriores'

### DIFF
--- a/components/navbar.html
+++ b/components/navbar.html
@@ -25,7 +25,7 @@
                         data-bs-toggle="dropdown" aria-expanded="false">Mais</a>
                     <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdownBlog">
                         <li><a class="dropdown-item" href="faq.html">FAQ</a></li>
-                        <li><a class="dropdown-item" href="proceedings.html">Edições Anteriores</a></li>
+                        <!-- <li><a class="dropdown-item" href="proceedings.html">Edições Anteriores</a></li> -->
                         <!--
                         <li><a class="dropdown-item" href="assets/posters/poster-xvi.pdf" target="_blank">Divulgação</a>
                         -->


### PR DESCRIPTION
Hide access to the "Edições Anteriores" tab due to the electoral blackout period.